### PR TITLE
[#55] BUGFIX Flush symbol and expression buffers separately

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,1 @@
-
+[#55] BUGFIX Flush symbol and expression buffers separately


### PR DESCRIPTION
Resolves #55  

Both buffers were being flushed when the expression buffer reached a threshold parameter, making it possible for the symbol buffer to overflow in some particular scenarios.

The fix is to force both buffers to flush whenever one of them reaches a threshold parameter.